### PR TITLE
https on localhost added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ dist
 
 client/build
 client/storybook-static
+cert/

--- a/server.js
+++ b/server.js
@@ -3,6 +3,9 @@ const express = require("express");
 const path = require("path");
 const cookieParser = require("cookie-parser");
 
+const https = require("https");
+const fs = require("fs");
+
 const { connect } = require("./lib/api/database");
 
 const documents = require("./lib/routes/documents");
@@ -29,7 +32,18 @@ app.get("*", (request, response) => {
 async function run() {
   console.log("Connecting to database ...");
   await connect(process.env.DB_URL);
-  app.listen(process.env.PORT || 6000);
+  // app.listen(process.env.PORT || 6000);
+  https
+    .createServer(
+      {
+        key: fs.readFileSync("./cert/server.key"),
+        cert: fs.readFileSync("./cert/server.cert"),
+      },
+      app
+    )
+    .listen(process.env.PORT || 6000, () => {
+      console.log("Listening...");
+    });
 }
 
 run();


### PR DESCRIPTION
1. create certificates

https://flaviocopes.com/react-how-to-configure-https-localhost/
https://flaviocopes.com/express-https-self-signed-certificate/

````node
openssl req -nodes -new -x509 -keyout server.key -out server.cert
`````
after typing in that, fill in the the following ...

````node
Generating a 1024 bit RSA private key
...........++++++
.........++++++
writing new private key to 'server.key'
-----
You are about to be asked to enter information that will be incorporated into your certificate request.
What you are about to enter is what is called a Distinguished Name or a DN.
There are quite a few fields but you can leave some blank
For some fields there will be a default value,
If you enter '.', the field will be left blank.
-----
Country Name (2 letter code) [AU]:
State or Province Name (full name) [Some-State]:
Locality Name (eg, city) []:
Organization Name (eg, company) [Internet Widgits Pty Ltd]:
Organizational Unit Name (eg, section) []:
Common Name (e.g. server FQDN or YOUR name) []: localhost
Email Address []: name@email.de
````

2. configuring server.js

https://flaviocopes.com/express-https-self-signed-certificate/

```js
const https = require('https');
const fs = require('fs');
const app = express();
const port = process.env.PORT || 3000;

// ...

https.createServer({
  key: fs.readFileSync('server.key'),
  cert: fs.readFileSync('server.cert')
}, app).listen(port, () => {
  console.log('Listening...')
})
```